### PR TITLE
Support specifying member name on business rule validation messages.

### DIFF
--- a/Peasy.Tests/RuleBaseTests.cs
+++ b/Peasy.Tests/RuleBaseTests.cs
@@ -19,7 +19,7 @@ namespace Peasy.Core.Tests
         public void Valid_Rule_Does_Not_Contain_An_Error_Message_After_Validation()
         {
             var rule = new TrueRule().Validate();
-            rule.ErrorMessage.ShouldBe(null);
+            rule.ErrorMessages.ShouldBeEmpty();
         }
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace Peasy.Core.Tests
         public void Invalid_Rule_Contains_An_Error_Message_After_Validation()
         {
             var rule = new FalseRule1().Validate();
-            rule.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -41,7 +41,7 @@ namespace Peasy.Core.Tests
         {
             var rule1 = new TrueRule().IfValidThenValidate(new FalseRule1()).Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace Peasy.Core.Tests
         {
             var rule1 = new FalseRule1().IfValidThenValidate(new FalseRule2()).Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace Peasy.Core.Tests
                                 .IfValidThenValidate(new FalseRule1(), new FalseRule2(), new FalseRule3())
                                 .Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -69,7 +69,7 @@ namespace Peasy.Core.Tests
                                 .IfValidThenValidate(new TrueRule(), new TrueRule(), new FalseRule1())
                                 .Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -80,7 +80,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new FalseRule2(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         } 
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new FalseRule2(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessage.ShouldBe("FalseRule2 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule2 failed validation");
         } 
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new TrueRule(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessage.ShouldBe("FalseRule3 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule3 failed validation");
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace Peasy.Core.Tests
                             .IfValidThenValidate(new FalseRule1()
                                                       .IfValidThenValidate(new FalseRule2())).Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace Peasy.Core.Tests
                             .IfValidThenValidate(new TrueRule()
                                                       .IfValidThenValidate(new FalseRule1())).Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessage.ShouldBe("FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -278,7 +278,7 @@ namespace Peasy.Core.Tests
                               .Validate();
             output.ShouldBe("pass");
             output2.ShouldBe(string.Empty);
-            rule.ErrorMessage.ShouldBe("FalseRule2 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule2 failed validation");
         }
     }
 

--- a/Peasy.Tests/RuleBaseTests.cs
+++ b/Peasy.Tests/RuleBaseTests.cs
@@ -33,7 +33,7 @@ namespace Peasy.Core.Tests
         public void Invalid_Rule_Contains_An_Error_Message_After_Validation()
         {
             var rule = new FalseRule1().Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -41,7 +41,7 @@ namespace Peasy.Core.Tests
         {
             var rule1 = new TrueRule().IfValidThenValidate(new FalseRule1()).Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace Peasy.Core.Tests
         {
             var rule1 = new FalseRule1().IfValidThenValidate(new FalseRule2()).Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace Peasy.Core.Tests
                                 .IfValidThenValidate(new FalseRule1(), new FalseRule2(), new FalseRule3())
                                 .Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -69,7 +69,7 @@ namespace Peasy.Core.Tests
                                 .IfValidThenValidate(new TrueRule(), new TrueRule(), new FalseRule1())
                                 .Validate();
             rule1.IsValid.ShouldBe(false);
-            rule1.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule1.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -80,7 +80,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new FalseRule2(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         } 
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new FalseRule2(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule2 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule2 failed validation");
         } 
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace Peasy.Core.Tests
                               .IfValidThenValidate(new TrueRule(), new FalseRule3())
                               .Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule3 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule3 failed validation");
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace Peasy.Core.Tests
                             .IfValidThenValidate(new FalseRule1()
                                                       .IfValidThenValidate(new FalseRule2())).Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace Peasy.Core.Tests
                             .IfValidThenValidate(new TrueRule()
                                                       .IfValidThenValidate(new FalseRule1())).Validate();
             rule.IsValid.ShouldBe(false);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule1 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule1 failed validation");
         }
 
         [TestMethod]
@@ -278,7 +278,7 @@ namespace Peasy.Core.Tests
                               .Validate();
             output.ShouldBe("pass");
             output2.ShouldBe(string.Empty);
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "FalseRule2 failed validation");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "FalseRule2 failed validation");
         }
     }
 

--- a/Peasy.Tests/Rules/ConcurrencyCheckRuleTests.cs
+++ b/Peasy.Tests/Rules/ConcurrencyCheckRuleTests.cs
@@ -32,7 +32,7 @@ namespace Peasy.Tests.Rules
             var obj1 = new ConcurrencyMock() { Version = "1" };
             var obj2 = new ConcurrencyMock() { Version = "2" };
             var rule = new ConcurrencyCheckRule(obj1, obj2);
-            rule.Validate().ErrorMessage.ShouldNotBeEmpty();
+            rule.Validate().ErrorMessages.ShouldNotBeEmpty();
         }
     }
 

--- a/Peasy.Tests/Rules/GreaterThanZeroRuleTests.cs
+++ b/Peasy.Tests/Rules/GreaterThanZeroRuleTests.cs
@@ -25,7 +25,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_On_Invalid()
         {
             var greaterThanZeroRule = new GreaterThanZeroRule(0, "the supplied value must be greater than 0");
-            greaterThanZeroRule.Validate().ErrorMessages.ShouldContainKeyAndValue(null, "the supplied value must be greater than 0");
+            greaterThanZeroRule.Validate().ErrorMessages.ShouldContainKeyAndValue(string.Empty, "the supplied value must be greater than 0");
         }
     }
 }

--- a/Peasy.Tests/Rules/GreaterThanZeroRuleTests.cs
+++ b/Peasy.Tests/Rules/GreaterThanZeroRuleTests.cs
@@ -25,7 +25,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_On_Invalid()
         {
             var greaterThanZeroRule = new GreaterThanZeroRule(0, "the supplied value must be greater than 0");
-            greaterThanZeroRule.Validate().ErrorMessage.ShouldBe("the supplied value must be greater than 0");
+            greaterThanZeroRule.Validate().ErrorMessages.ShouldContainKeyAndValue(null, "the supplied value must be greater than 0");
         }
     }
 }

--- a/Peasy.Tests/Rules/ValueRequiredRuleTests.cs
+++ b/Peasy.Tests/Rules/ValueRequiredRuleTests.cs
@@ -26,7 +26,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Integer_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0, "id").Validate();
-            rule.ErrorMessage.ShouldBe("id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Long_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0L, "id").Validate();
-            rule.ErrorMessage.ShouldBe("id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Decimal_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0M, "id").Validate();
-            rule.ErrorMessage.ShouldBe("id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_String_Empty_Is_Supplied()
         {
             var rule = new ValueRequiredRule("", "id").Validate();
-            rule.ErrorMessage.ShouldBe("id must be supplied");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be supplied");
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Guid_Empty_Is_Supplied()
         {
             var rule = new ValueRequiredRule(new Guid(), "id").Validate();
-            rule.ErrorMessage.ShouldBe("id must be supplied");
+            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be supplied");
         }
     }
 }

--- a/Peasy.Tests/Rules/ValueRequiredRuleTests.cs
+++ b/Peasy.Tests/Rules/ValueRequiredRuleTests.cs
@@ -26,7 +26,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Integer_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0, "id").Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Long_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0L, "id").Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Decimal_Less_Than_One_Supplied()
         {
             var rule = new ValueRequiredRule(0M, "id").Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be greater than 0");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "id must be greater than 0");
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_String_Empty_Is_Supplied()
         {
             var rule = new ValueRequiredRule("", "id").Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be supplied");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "id must be supplied");
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace Peasy.Tests.Rules
         public void Sets_ErrorMessage_When_Guid_Empty_Is_Supplied()
         {
             var rule = new ValueRequiredRule(new Guid(), "id").Validate();
-            rule.ErrorMessages.ShouldContainKeyAndValue(null, "id must be supplied");
+            rule.ErrorMessages.ShouldContainKeyAndValue(string.Empty, "id must be supplied");
         }
     }
 }

--- a/Peasy.Tests/SharedClasses.cs
+++ b/Peasy.Tests/SharedClasses.cs
@@ -11,7 +11,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessages[null] = "FalseRule1 failed validation";
+            ErrorMessages[string.Empty] = "FalseRule1 failed validation";
         }
     }
 
@@ -20,7 +20,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessages[null] = "FalseRule2 failed validation";
+            ErrorMessages[string.Empty] = "FalseRule2 failed validation";
         }
     }
 
@@ -29,7 +29,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessages[null] = "FalseRule3 failed validation";
+            ErrorMessages[string.Empty] = "FalseRule3 failed validation";
         }
     }
 

--- a/Peasy.Tests/SharedClasses.cs
+++ b/Peasy.Tests/SharedClasses.cs
@@ -11,7 +11,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessage = "FalseRule1 failed validation";
+            ErrorMessages[null] = "FalseRule1 failed validation";
         }
     }
 
@@ -20,7 +20,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessage = "FalseRule2 failed validation";
+            ErrorMessages[null] = "FalseRule2 failed validation";
         }
     }
 
@@ -29,7 +29,7 @@ namespace Peasy.Core.Tests
         protected override void OnValidate()
         {
             IsValid = false;
-            ErrorMessage = "FalseRule3 failed validation";
+            ErrorMessages[null] = "FalseRule3 failed validation";
         }
     }
 

--- a/Peasy/BusinessServiceBase.cs
+++ b/Peasy/BusinessServiceBase.cs
@@ -23,9 +23,14 @@ namespace Peasy
         protected override IEnumerable<ValidationResult> GetValidationResultsForDelete(TKey id, ExecutionContext<T> context)
         {
             var rule = id.CreateValueRequiredRule(nameof(id)).Validate();
-            if (!rule.IsValid)
-                yield return new ValidationResult(rule.ErrorMessage, new string[] { typeof(T).Name });
-        }
+			if (!rule.IsValid)
+			{
+				foreach (var pair in rule.ErrorMessages)
+				{
+					yield return new ValidationResult(pair.Value, new[] { pair.Key ?? typeof(T).Name });
+				}
+			}
+		}
 
         /// <summary>
         /// Supplies validation results to GetByIDCommand()
@@ -33,8 +38,14 @@ namespace Peasy
         protected override IEnumerable<ValidationResult> GetValidationResultsForGetByID(TKey id, ExecutionContext<T> context)
         {
             var rule = id.CreateValueRequiredRule(nameof(id)).Validate();
-            if (!rule.IsValid)
-                yield return new ValidationResult(rule.ErrorMessage, new string[] { typeof(T).Name });
+	        if (!rule.IsValid)
+	        {
+		        foreach (var pair in rule.ErrorMessages)
+		        {
+			        yield return new ValidationResult(pair.Value, new[] {pair.Key ?? typeof(T).Name});
+		        }
+	        }
+                
         }
 
         /// <summary>
@@ -59,7 +70,7 @@ namespace Peasy
                 {
                     var rule = new ConcurrencyCheckRule(current as IVersionContainer, entity as IVersionContainer).Validate();
                     if (!rule.IsValid)
-                        throw new ConcurrencyException(rule.ErrorMessage);
+                        throw new ConcurrencyException(rule.ErrorMessages.First().Value);
                 }
 
                 entity.RevertNonEditableValues(current);
@@ -87,7 +98,7 @@ namespace Peasy
                 {
                     var rule = new ConcurrencyCheckRule(current as IVersionContainer, entity as IVersionContainer).Validate();
                     if (!rule.IsValid)
-                        throw new ConcurrencyException(rule.ErrorMessage);
+                        throw new ConcurrencyException(rule.ErrorMessages.First().Value);
 
                 }
                 entity.RevertNonEditableValues(current);

--- a/Peasy/Extensions/IRuleExtensions.cs
+++ b/Peasy/Extensions/IRuleExtensions.cs
@@ -11,8 +11,8 @@ namespace Peasy
         {
             var rules = businessRules.Select(rule => rule.Validate())
                                      .Where(rule => !rule.IsValid)
-                                     .Select(rule => new ValidationResult(rule.ErrorMessage, new string[] { entityName }));
-            return rules;
+									 .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { e.Key ?? entityName })));
+			return rules;
         }
 
         public static IEnumerable<ValidationResult> GetValidationResults(this IEnumerable<IRule> businessRules)
@@ -24,7 +24,7 @@ namespace Peasy
         {
             var rules  = await Task.WhenAll(businessRules.Select(r => r.ValidateAsync()));
             return rules.Where(rule => !rule.IsValid)
-                        .Select(rule => new ValidationResult(rule.ErrorMessage, new string[] { entityName }));
+                        .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { e.Key ?? entityName })));
         }
 
         public static Task<IEnumerable<ValidationResult>> GetValidationResultsAsync(this IEnumerable<IRule> businessRules)

--- a/Peasy/Extensions/IRuleExtensions.cs
+++ b/Peasy/Extensions/IRuleExtensions.cs
@@ -11,7 +11,7 @@ namespace Peasy
         {
             var rules = businessRules.Select(rule => rule.Validate())
                                      .Where(rule => !rule.IsValid)
-									 .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { e.Key ?? entityName })));
+									 .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { string.IsNullOrEmpty(e.Key) ? entityName : e.Key })));
 			return rules;
         }
 
@@ -24,7 +24,7 @@ namespace Peasy
         {
             var rules  = await Task.WhenAll(businessRules.Select(r => r.ValidateAsync()));
             return rules.Where(rule => !rule.IsValid)
-                        .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { e.Key ?? entityName })));
+                        .SelectMany(rule => rule.ErrorMessages.Select(e => new ValidationResult(e.Value, new string[] { string.IsNullOrEmpty(e.Key) ? entityName : e.Key })));
         }
 
         public static Task<IEnumerable<ValidationResult>> GetValidationResultsAsync(this IEnumerable<IRule> businessRules)

--- a/Peasy/IRule.cs
+++ b/Peasy/IRule.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Peasy
 {
     public interface IRule
     {
-        string ErrorMessage { get; }
+        IDictionary<string, string> ErrorMessages { get; }
         IRule IfInvalidThenExecute(Action<IRule> method);
         IRule IfValidThenExecute(Action<IRule> method);
         IRule IfValidThenValidate(params IRule[] rule);

--- a/Peasy/RuleBase.cs
+++ b/Peasy/RuleBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Peasy.Extensions;
 
 namespace Peasy
 {
@@ -22,7 +23,7 @@ namespace Peasy
         /// <summary>
         /// Gets or sets the message to be supplied to caller in the event that no rule dependencies exist via IfValidThenValidate()
         /// </summary>
-        public string ErrorMessage { get; protected set; }
+        public IDictionary<string, string> ErrorMessages { get; protected set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets a value indicating whether this rule is valid.
@@ -55,8 +56,8 @@ namespace Peasy
                             rule.Validate();
                             if (!rule.IsValid)
                             {
-                                Invalidate(rule.ErrorMessage);
-                                _ifInvalidThenExecute?.Invoke(this);
+								rule.ErrorMessages.ForEach(e => Invalidate(e.Value, e.Key));
+								_ifInvalidThenExecute?.Invoke(this);
                                 break; // early exit, don't bother further rule execution
                             }
                         }
@@ -120,9 +121,9 @@ namespace Peasy
         /// Invalidates the rule
         /// </summary>
         /// <param name="errorMessage">The error message to associate with the broken rule</param>
-        protected virtual void Invalidate(string errorMessage)
+        protected virtual void Invalidate(string errorMessage, string memberName = null)
         {
-            ErrorMessage = errorMessage;
+	        ErrorMessages[memberName] = errorMessage;
             IsValid = false;
         }
 
@@ -141,7 +142,7 @@ namespace Peasy
                             await rule.ValidateAsync();
                             if (!rule.IsValid)
                             {
-                                Invalidate(rule.ErrorMessage);
+	                            rule.ErrorMessages.ForEach(e => Invalidate(e.Value, e.Key));
                                 _ifInvalidThenExecute?.Invoke(this);
                                 break; // early exit, don't bother further rule execution
                             }

--- a/Peasy/RuleBase.cs
+++ b/Peasy/RuleBase.cs
@@ -123,7 +123,7 @@ namespace Peasy
         /// <param name="errorMessage">The error message to associate with the broken rule</param>
         protected virtual void Invalidate(string errorMessage, string memberName = null)
         {
-	        ErrorMessages[memberName] = errorMessage;
+	        ErrorMessages[memberName ?? string.Empty] = errorMessage;
             IsValid = false;
         }
 

--- a/Peasy/project.lock.json
+++ b/Peasy/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "targets": {
     ".NETPortable,Version=v4.5,Profile=Profile111": {
       "System.ComponentModel.Annotations/4.3.0": {
@@ -197,9 +197,38 @@
     ],
     ".NETPortable,Version=v4.5,Profile=Profile111": []
   },
-  "tools": {},
-  "projectFileToolGroups": {},
   "packageFolders": {
-    "C:\\Users\\aaron\\.nuget\\packages\\": {}
+    "C:\\Users\\PageSincler\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackagesFallback\\": {}
+  },
+  "project": {
+    "restore": {
+      "projectUniqueName": "C:\\code\\Peasy.NET\\Peasy\\Peasy.csproj",
+      "projectName": "Peasy",
+      "projectPath": "C:\\code\\Peasy.NET\\Peasy\\Peasy.csproj",
+      "projectJsonPath": "C:\\code\\Peasy.NET\\Peasy\\project.json",
+      "packagesPath": "C:\\Users\\PageSincler\\.nuget\\packages\\",
+      "outputPath": "C:\\code\\Peasy.NET\\Peasy\\obj\\",
+      "projectStyle": "ProjectJson",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackagesFallback\\"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\PageSincler\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.Fallback.config"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "C:\\Users\\PageSincler\\.dotnet\\NuGetFallbackFolder": {},
+        "https://api.nuget.org/v3/index.json": {}
+      }
+    },
+    "dependencies": {
+      "System.ComponentModel.Annotations": "[4.3.0, )"
+    },
+    "frameworks": {
+      "portable45-net45+win8+wpa81": {}
+    }
   }
 }


### PR DESCRIPTION
When invalidating business rules:

1.  It should now be possible to specify which property on the entity caused the error.  This is similar to the way the validation rules work in conjunction with data annotations.  If a property name is not provided, the entity name default will be used (just as before).

2.  The IRule ErrorMessage property is now a dictionary by member name and error messages are aggregated into the dictionary every time Invalidate() is called.  This will allow support for flagging multiple entity properties as invalid in scenarios such as co-dependent property validation that is not possible with data annotations.